### PR TITLE
Add co-author and fix slide title

### DIFF
--- a/static/csf-panel.html
+++ b/static/csf-panel.html
@@ -429,7 +429,7 @@
     <div class="title-decoration"></div>
     <div class="section-label animate-in" style="opacity:0">Karolinska Institutet · Dep. of Clinical Neuroscience &amp; Dep. of Neurobiology, Care Sciences and Society</div>
     <h1 class="animate-in" style="opacity:0">CSF Autophagy &amp; Lysosome<br>Biomarker Panel Discovery</h1>
-    <p class="title-meta animate-in" style="opacity:0">Pontus Plavén-Sigray</p>
+    <p class="title-meta animate-in" style="opacity:0">Pontus Plavén-Sigray and Aris Logothetis</p>
     <p class="title-meta animate-in" style="opacity:0; margin-top:0.3rem;">Translational pipeline · 12 datasets · ~3,600 samples · Mouse ↔ Human</p>
   </div>
 


### PR DESCRIPTION
## Summary
- Add Aris Logothetis as co-author on title slide
- Title already fixed from "Top 20" to "Top 10" in previous merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)